### PR TITLE
Allow 1.18+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ repositories {
 dependencies {
     implementation 'com.tchristofferson:ConfigUpdater:2.1'
     implementation 'org.ocpsoft.prettytime:prettytime:5.0.7.Final'
-    compileOnly 'org.spigotmc:spigot-api:1.20.2-R0.1-SNAPSHOT'
+    compileOnly 'org.spigotmc:spigot-api:1.18-R0.1-SNAPSHOT'
     compileOnly 'me.clip:placeholderapi:2.11.4'
     compileOnly 'net.luckperms:api:5.4'
 }


### PR DESCRIPTION
No point in not supporting it, as no API used is exclusive to any versions higher